### PR TITLE
Update /ping api for single endpoint setup

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,12 @@
 {
   "name": "template-typescript-vuejs",
+  "version": "1.0.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
+      "name": "template-typescript-vuejs",
+      "version": "1.0.0",
       "dependencies": {
         "core-js": "^3.6.5",
         "vue": "^3.0.0"

--- a/src/components/Ping.vue
+++ b/src/components/Ping.vue
@@ -40,7 +40,7 @@ export default defineComponent({
   methods: {
     async pingServer () {
       function createBaseUrl () {
-        const locationToMatchRegex = new RegExp('^http://localhost:[0-9]*')
+        const locationToMatchRegex = new RegExp('^http:\/\/localhost(:[0-9]+)?')
         if (locationToMatchRegex.test(window.location.origin)) {
           // The host:port serving the backend in a two endpoint setup
           return 'http://localhost:3000'

--- a/src/components/Ping.vue
+++ b/src/components/Ping.vue
@@ -39,7 +39,19 @@ export default defineComponent({
   },
   methods: {
     async pingServer () {
-      const response = await fetch(`http://localhost:3000/ping?ping=${this.ping}`)
+      function createBaseUrl () {
+        const locationToMatchRegex = new RegExp('^http://localhost:[0-9]*')
+        if (locationToMatchRegex.test(window.location.origin)) {
+          // The host:port serving the backend in a two endpoint setup
+          return 'http://localhost:3000'
+        }
+        // The current window URL in a single endpoint setup
+        // A /ping path_prefix serves the backend
+        return window.location.origin
+      }
+
+      const baseUrl = createBaseUrl()
+      const response = await fetch(`${baseUrl}/ping?ping=${this.ping}`)
       const data = await response.json()
       this.pong = data
     }

--- a/vue.config.js
+++ b/vue.config.js
@@ -1,0 +1,5 @@
+module.exports = {
+  devServer: {
+    disableHostCheck: true
+  }
+}


### PR DESCRIPTION
This PR updates the /ping api to handle single endpoint setup. Frontend/backend templates can now interact out of the box in any configuration.